### PR TITLE
Removed known hash from pooch.retrieve

### DIFF
--- a/climkern/download.py
+++ b/climkern/download.py
@@ -14,7 +14,7 @@ def download():
 
     retrieve(
         url="doi:10.5281/zenodo.10223376/data.zip",
-        known_hash="md5:8718deb9ed358dde36f3a9c1fd8a46c4",
+        known_hash=None,
         fname=fname,
         path=path,
         processor=Unzip(extract_dir="data"),


### PR DESCRIPTION
Fixes #10 

I removed the known hash argument from the pooch.retrieve used in the download function. Although this is not the best from a security perspective, it avoids the issue of having to update the known hash every time an update is made to the ClimKern data on Zenodo.