### PR TITLE
Update wv options

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The water vapor and surface albedo feedbacks are calculated similarly:
 ```python
 q_lw,q_sw = ck.calc_q_feedbacks(ctrl.Q,ctrl.T,ctrl.PS,
                                 pert.Q,pert.PS,pert.TROP_P,
-                                kern="GFDL",method="zelinka")
+                                kern="GFDL",method=3)
 alb = ck.calc_alb_feedback(ctrl.FSUS,ctrl.FSDS,
                            pert.FSUS,pert.FSDS,
                            kern="GFDL")

--- a/climkern/frontend.py
+++ b/climkern/frontend.py
@@ -138,8 +138,8 @@ def calc_T_feedbacks(ctrl_ta,ctrl_ts,ctrl_ps,pert_ta,pert_ts,pert_ps,
         DataArray containing tropopause pressure in the perturbed simulation.
         3D with coordinates of time, latitude, and longitude and units of Pa
         or hPa. If not provided, ClimKern will assume a tropopause height of
-        300 hPa at the equator, linearly decreasing with the cosine of
-        latitude to 100 hPa at the poles.
+        100 hPa at the equator, linearly descending with the cosine of
+        latitude to 300 hPa at the poles.
 
     kern : string, optional
         String specifying the name of the desired kernel. Defaults to "GFDL".
@@ -245,7 +245,7 @@ def calc_T_feedbacks(ctrl_ta,ctrl_ts,ctrl_ps,pert_ta,pert_ts,pert_ps,
 
 
 def calc_q_feedbacks(ctrl_q,ctrl_ta,ctrl_ps,pert_q,pert_ps,pert_trop=None,
-                     kern='GFDL',sky='all-sky',method='pendergrass'):
+                     kern='GFDL',sky='all-sky',method=1):
     """
     Calculate the raditive pertubations (W/m^2), LW & SW, at the TOA from 
     changes in specific humidity using user-specified kernel. Horizontal
@@ -282,8 +282,8 @@ def calc_q_feedbacks(ctrl_q,ctrl_ta,ctrl_ps,pert_q,pert_ps,pert_trop=None,
         DataArray containing tropopause pressure in the perturbed simulation.
         3D with coordinates of time, latitude, and longitude and units of Pa
         or hPa. If not provided, ClimKern will assume a tropopause height of
-        300 hPa at the equator, linearly decreasing with the cosine of
-        latitude to 100 hPa at the poles.
+        100 hPa at the equator, linearly descending with the cosine of
+        latitude to 300 hPa at the poles.
 
     kern : string, optional
         String specifying the name of the desired kernel. Defaults to "GFDL".
@@ -292,10 +292,16 @@ def calc_q_feedbacks(ctrl_q,ctrl_ta,ctrl_ps,pert_q,pert_ps,pert_trop=None,
         String, either "all-sky" or "clear-sky", specifying whether to
         calculate the all-sky or clear-sky feedbacks. Defaults to "all-sky".
 
-    method : string, optional
+    method : int, optional
         Specifies the method to use to calculate the specific humidity
-        feedback. Options are "pendergrass" (default), "kramer", "zelinka",
-        and "linear". 
+        feedback. Options 1, 2, and 3 use the change in the natural logarithm of
+        specific humidity, while 4 uses the lienar change. The options are:
+        1 -- Uses the fractional change approximation of logarithms in the specific
+        humidity response & normalization factor.
+        2 -- Uses the fractional change approximation of logarithms in the 
+        normalization factor.
+        3 -- Does not use the fractional change approximation.
+        4 -- Uses the linear change in specific humidity.
 
     Returns
     -------
@@ -309,6 +315,13 @@ def calc_q_feedbacks(ctrl_q,ctrl_ta,ctrl_ps,pert_q,pert_ps,pert_trop=None,
         changes in specific humidity with coordinates of time, latitude,
         and longitude.
     """
+    # Issue warning if user provides old keywords for the method argument
+    if method in ["pendergrass","kramer","zelinka","linear"]:
+        warnings.warn("Name keywords are deprecated and will be removed"+
+                      " from future versions of ClimKern. Please use \"1\", "+
+                      "\"2\", \"3\", or \"4\" instead.",FutureWarning)
+        mapping = {"pendergrass":1,"kramer":2,"zelinka":3,"linear":4}
+        method = mapping[method]
     # get correct keys for all-sky or clear-sky
     qlw_key = 'lw_q' if check_sky(sky)=='all-sky' else 'lwclr_q'
     qsw_key = 'sw_q' if sky=='all-sky' else 'swclr_q'
@@ -354,11 +367,11 @@ def calc_q_feedbacks(ctrl_q,ctrl_ta,ctrl_ps,pert_q,pert_ps,pert_trop=None,
     ctrl_q_clim_tiled = tile_data(ctrl_q_clim,pert_q)
 
     # calculate specific humidity response using user-specified method
-    if(method=='pendergrass'):
+    if(method==1):
         diff_q = (pert_q - ctrl_q_clim_tiled)/ctrl_q_clim_tiled
-    elif(method=='linear'):
+    elif(method==4):
         diff_q = pert_q - ctrl_q_clim_tiled
-    elif(method in ['kramer','zelinka']):
+    elif(method in [2,3]):
         diff_q = np.log(pert_q.where(pert_q>0)) - np.log(
             ctrl_q_clim_tiled.where(ctrl_q_clim_tiled>0))
     else:
@@ -752,8 +765,8 @@ def calc_strato_T(ctrl_ta,pert_ta,pert_ps,pert_trop=None,kern='GFDL',
         DataArray containing tropopause pressure in the perturbed simulation.
         3D with coordinates of time, latitude, and longitude and units of Pa
         or hPa. If not provided, ClimKern will assume a tropopause height of
-        300 hPa at the equator, linearly decreasing with the cosine of
-        latitude to 100 hPa at the poles.
+        100 hPa at the equator, linearly descending with the cosine of
+        latitude to 300 hPa at the poles.
 
     kern : string, optional
         String specifying the name of the desired kernel. Defaults to "GFDL".
@@ -816,7 +829,7 @@ def calc_strato_T(ctrl_ta,pert_ta,pert_ps,pert_trop=None,kern='GFDL',
     return(T_feedback)
 
 def calc_strato_q(ctrl_q,ctrl_ta,pert_q,pert_ps,pert_trop=None,
-                     kern='GFDL',sky='all-sky',method='pendergrass'):
+                     kern='GFDL',sky='all-sky',method=1):
     """
     Calculate the raditive pertubations (W/m^2), LW & SW, at the TOA from 
     changes in stratospheric specific humidity using user-specified kernel.
@@ -848,8 +861,8 @@ def calc_strato_q(ctrl_q,ctrl_ta,pert_q,pert_ps,pert_trop=None,
         DataArray containing tropopause pressure in the perturbed simulation.
         3D with coordinates of time, latitude, and longitude and units of Pa
         or hPa. If not provided, ClimKern will assume a tropopause height of
-        300 hPa at the equator, linearly decreasing with the cosine of
-        latitude to 100 hPa at the poles.
+        100 hPa at the equator, linearly descending with the cosine of
+        latitude to 300 hPa at the poles.
 
     kern : string, optional
         String specifying the name of the desired kernel. Defaults to "GFDL".
@@ -858,10 +871,16 @@ def calc_strato_q(ctrl_q,ctrl_ta,pert_q,pert_ps,pert_trop=None,
         String, either "all-sky" or "clear-sky", specifying whether to
         calculate the all-sky or clear-sky feedbacks. Defaults to "all-sky".
 
-    method : string, optional
+    method : int, optional
         Specifies the method to use to calculate the specific humidity
-        feedback. Options are "pendergrass" (default), "kramer", "zelinka",
-        and "linear". 
+        feedback. Options 1, 2, and 3 use the change in the natural logarithm of
+        specific humidity, while 4 uses the lienar change. The options are:
+        1 -- Uses the fractional change approximation of logarithms in the specific
+        humidity response & normalization factor.
+        2 -- Uses the fractional change approximation of logarithms in the 
+        normalization factor.
+        3 -- Does not use the fractional change approximation.
+        4 -- Uses the linear change in specific humidity.
 
     Returns
     -------
@@ -875,6 +894,14 @@ def calc_strato_q(ctrl_q,ctrl_ta,pert_q,pert_ps,pert_trop=None,
         perturbations from changes in specific humidity in the stratosphere
         (shortwave). Has coordinates of time, lat, and lon.
     """
+    # Issue warning if user provides old keywords for the method argument
+    if method in ["pendergrass","kramer","zelinka","linear"]:
+        warnings.warn("Name keywords are deprecated and will be removed"+
+                      " from future versions of ClimKern. Please use \"1\", "+
+                      "\"2\", \"3\", or \"4\" instead.",FutureWarning)
+        mapping = {"pendergrass":1,"kramer":2,"zelinka":3,"linear":4}
+        method = mapping[method]
+
     # get correct keys for all-sky or clear-sky
     qlw_key = 'lw_q' if check_sky(sky)=='all-sky' else 'lwclr_q'
     qsw_key = 'sw_q' if sky=='all-sky' else 'swclr_q'
@@ -915,11 +942,11 @@ def calc_strato_q(ctrl_q,ctrl_ta,pert_q,pert_ps,pert_trop=None,
     # tile control climatology to match length of pert simulation time dim
     ctrl_q_clim_tiled = tile_data(ctrl_q_clim,pert_q)
     
-    if(method=='pendergrass'):
+    if(method==1):
         diff_q = (pert_q - ctrl_q_clim_tiled)/ctrl_q_clim_tiled
-    elif(method=='linear'):
+    elif(method==4):
         diff_q = pert_q - ctrl_q_clim_tiled
-    elif(method in ['kramer','zelinka']):
+    elif(method in [2,3]):
         diff_q = np.log(pert_q) - np.log(ctrl_q_clim_tiled)
     else:
         raise ValueError(
@@ -966,7 +993,7 @@ def calc_strato_q(ctrl_q,ctrl_ta,pert_q,pert_ps,pert_trop=None,
 
 def calc_RH_feedback(ctrl_q,ctrl_ta,ctrl_ps,pert_q,pert_ta,pert_ps,
                      pert_trop=None,kern='GFDL',sky='all-sky',
-                     method='pendergrass'):
+                     method=1):
     """
     Calculate the TOA radiative perturbations from changes in relative
     humidity following Held & Shell (2012). Horizontal resolution is 
@@ -1003,8 +1030,8 @@ def calc_RH_feedback(ctrl_q,ctrl_ta,ctrl_ps,pert_q,pert_ta,pert_ps,
         DataArray containing tropopause pressure in the perturbed simulation.
         3D with coordinates of time, latitude, and longitude and units of Pa
         or hPa. If not provided, ClimKern will assume a tropopause height of
-        300 hPa at the equator, linearly decreasing with the cosine of
-        latitude to 100 hPa at the poles.
+        100 hPa at the equator, linearly descending with the cosine of
+        latitude to 300 hPa at the poles.
 
     kern : string, optional
         String specifying the name of the desired kernel. Defaults to "GFDL".
@@ -1013,10 +1040,16 @@ def calc_RH_feedback(ctrl_q,ctrl_ta,ctrl_ps,pert_q,pert_ta,pert_ps,
         String, either "all-sky" or "clear-sky", specifying whether to
         calculate the all-sky or clear-sky feedbacks. Defaults to "all-sky".
 
-    method : string, optional
+    method : int, optional
         Specifies the method to use to calculate the specific humidity
-        feedback. Options are "pendergrass" (default), "kramer", "zelinka",
-        and "linear". 
+        feedback. Options 1, 2, and 3 use the change in the natural logarithm of
+        specific humidity, while 4 uses the lienar change. The options are:
+        1 -- Uses the fractional change approximation of logarithms in the specific
+        humidity response & normalization factor.
+        2 -- Uses the fractional change approximation of logarithms in the 
+        normalization factor.
+        3 -- Does not use the fractional change approximation.
+        4 -- Uses the linear change in specific humidity.
 
     Returns
     -------
@@ -1025,6 +1058,14 @@ def calc_RH_feedback(ctrl_q,ctrl_ta,ctrl_ps,pert_q,pert_ta,pert_ps,
         perturbations from changes in relative humidity (LW+SW).
         Has coordinates of time, lat, and lon.
     """
+    # Issue warning if user provides old keywords for the method argument
+    if method in ["pendergrass","kramer","zelinka","linear"]:
+        warnings.warn("Name keywords are deprecated and will be removed"+
+                      " from future versions of ClimKern. Please use \"1\", "+
+                      "\"2\", \"3\", or \"4\" instead.",FutureWarning)
+        mapping = {"pendergrass":1,"kramer":2,"zelinka":3,"linear":4}
+        method = mapping[method]
+
     # get correct keys for all-sky or clear-sky
     qlw_key = 'lw_q' if check_sky(sky)=='all-sky' else 'lwclr_q'
     qsw_key = 'sw_q' if sky=='all-sky' else 'swclr_q'
@@ -1070,11 +1111,11 @@ def calc_RH_feedback(ctrl_q,ctrl_ta,ctrl_ps,pert_q,pert_ta,pert_ps,
     # tile control climatology to match length of pert simulation time dim
     ctrl_q_clim_tiled = tile_data(ctrl_q_clim,pert_q)
     
-    if(method=='pendergrass'):
+    if(method==1):
         diff_q = (pert_q - ctrl_q_clim_tiled)/ctrl_q_clim_tiled
-    elif(method=='linear'):
+    elif(method==4):
         diff_q = pert_q - ctrl_q_clim_tiled
-    elif(method in ['kramer','zelinka']):
+    elif(method in [2,3]):
         diff_q = np.log(pert_q) - np.log(ctrl_q_clim_tiled)
     else:
         raise ValueError(

--- a/climkern/tests/test_frontend.py
+++ b/climkern/tests/test_frontend.py
@@ -1,0 +1,32 @@
+import xarray as xr
+
+from climkern.frontend import *
+
+
+def test_calc_T_feedbacks(
+    ctrl: xr.Dataset, pert: xr.Dataset, dTS_glob_avg: xr.DataArray
+) -> None:
+    LR, Planck = calc_T_feedbacks(
+        ctrl.T, ctrl.TS, ctrl.PS, pert.T, pert.TS, pert.PS, pert.TROP_P, kern="GFDL"
+    )
+    LR_val = (spat_avg(LR) / dTS_glob_avg).mean()
+    Planck_val = (spat_avg(Planck) / dTS_glob_avg).mean()
+    xr.testing.assert_allclose(LR_val, xr.DataArray(-0.41), atol=0.01)
+    xr.testing.assert_allclose(Planck_val, xr.DataArray(-3.12), atol=0.01)
+
+
+def test_albedo_feedbacks(
+    ctrl: xr.Dataset, pert: xr.Dataset, dTS_glob_avg: xr.DataArray
+) -> None:
+    alb = calc_alb_feedback(ctrl.FSUS, ctrl.FSDS, pert.FSUS, pert.FSDS, kern="GFDL")
+    val_to_test = (spat_avg(alb) / dTS_glob_avg).mean()
+    xr.testing.assert_allclose(val_to_test, xr.DataArray(0.38), atol=0.01)
+
+def test_calc_q_feedbacks(
+        ctrl: xr.Dataset, pert: xr.Dataset, dTS_glob_avg: xr.DataArray
+) -> None:
+    lw,sw = calc_q_feedbacks(
+        ctrl.Q,ctrl.T,ctrl.PS,pert.Q,pert.PS,pert.TROP_P,kern="GFDL",method=3
+    )
+    q_val = (spat_avg(lw + sw) / dTS_glob_avg).mean()
+    xr.testing.assert_allclose(q_val,xr.DataArray(1.44), atol=0.01)

--- a/climkern/util.py
+++ b/climkern/util.py
@@ -212,7 +212,7 @@ def calc_q_norm(ctrl_ta,ctrl_q,method):
     ta1K.attrs = ctrl_ta.attrs
     qs1K = __calc_qs__(ta1K)
 
-    if(method=='linear'):
+    if(method==4):
         # get the new specific humidity using the same RH
         q1K = qs1K * RH
         q1K['units'] = 'kg/kg'
@@ -221,14 +221,14 @@ def calc_q_norm(ctrl_ta,ctrl_q,method):
         dq1K = 1000 * (q1K - ctrl_q)
         return(dq1K)
         
-    elif(method in ['pendergrass','kramer']):
+    elif(method in [1,2]):
         dqsdT = qs1K - qs0
         dqdT = RH * dqsdT
 
         dlogqdT = 1000 * (dqdT / ctrl_q)
         return(dlogqdT)
         
-    elif(method=='zelinka'):
+    elif(method==3):
         dlogqdT = 1000 * (np.log(qs1K.where(qs1K>0)) - np.log(
             qs0.where(qs0>0)))
         return(dlogqdT)
@@ -251,8 +251,8 @@ def check_coords(ds,ndim=3):
         ds = ds.rename({'month':'time'})
     else:
         raise AttributeError(
-            'There is no \'time\' or \'month\' dimension in\
-        one of the input DataArrays. Please rename your time dimension(s).')
+            "There is no \'time\' or \'month\' dimension in"+
+            "one of the input DataArrays. Please rename your time dimension(s).")
 
     # lat and lon
     if('lat' not in ds.dims and 'latitude' not in ds.dims):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "Ty Janoski", email="tyfolino@gmail.com"},
 ]
 requires-python = ">= 3.9"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
     "xarray>=0.16.2",
     "cf-xarray>=0.5.1",


### PR DESCRIPTION
This PR includes changes to the water vapor feedback calculation to remove last names as options in the "method" argument and replace them with numbers. It also adds details about the differences between the methods to the docstring.

Somehow, the pytests were lost in some prior commit. I am re-adding those.