### PR TITLE
Changed default value of `rf_sw` to None in `calc_cloud_LW_res`

### DIFF
--- a/climkern/frontend.py
+++ b/climkern/frontend.py
@@ -762,7 +762,7 @@ def calc_cloud_LW_res(ctrl_FLNT, pert_FLNT, t_lw, q_lw, rf_lw=None):
     return lw_cld_feedback
 
 
-def calc_cloud_SW_res(ctrl_FSNT, pert_FSNT, q_sw, alb_sw, rf_sw=0):
+def calc_cloud_SW_res(ctrl_FSNT, pert_FSNT, q_sw, alb_sw, rf_sw=None):
     """
     Calculate the radiative perturbation from the shortwave cloud feedback
     using the residual method outlined in Soden & Held (2006).


### PR DESCRIPTION
This fixes the default value of `rf_sw` in the `calc_cloud_LW_res` function from 0 to None. This allows the function to set `rf` to an array of zeros if not provided:
```
if (rf_lw is None):
   rf_lw = xr.zeros_like(dR_lw)
```
If set to 0 as before, the `if`-statement was ignored.